### PR TITLE
Remove unnecessary return from components

### DIFF
--- a/src/components/Combination.js
+++ b/src/components/Combination.js
@@ -1,32 +1,30 @@
 import React, { PropTypes } from 'react'
 import Color from 'color'
 
-const Combination = ({ colorOne, colorTwo }) => {
-  return (
-    <section className='cf bg-white'>
-      <div className='fl w-100 w-50-ns pv4 ph4' style={{ backgroundColor: colorOne, color: colorTwo }}>
-        <code className='f6 f4-ns mb2 db fw6'>{colorOne}</code>
-        <code className='f6 f5-ns mb2 db'>{Color(colorOne).hslString()}</code>
-        <code className='f6 f5-ns mb2 mb4-ns db'>{Color(colorOne).rgbString()}</code>
-        <h3 className='f3 f1-m f-headline-l mv0'>Aa Bb Cc</h3>
-        <p className='lh-copy measure'>
-          Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod.
-          <span className='dn di-ns'>Tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.</span>
-        </p>
-      </div>
-      <div className='fl w-100 w-50-ns pv4 ph4' style={{ backgroundColor: colorTwo, color: colorOne }}>
-        <code className='f6 f4-ns fw6 mb2 db'>{colorTwo}</code>
-        <code className='f6 f5-ns mb2 db'>{Color(colorTwo).hslString()}</code>
-        <code className='f6 f5-ns mb2 mb4-ns db'>{Color(colorTwo).rgbString()}</code>
-        <h3 className='f3 f1-m f-headline-l mv0'>Aa Bb Cc</h3>
-        <p className='lh-copy measure'>
-          Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod.
-          <span className='dn di-ns'>Tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.</span>
-        </p>
-      </div>
-    </section>
-  )
-}
+const Combination = ({ colorOne, colorTwo }) => (
+  <section className='cf bg-white'>
+    <div className='fl w-100 w-50-ns pv4 ph4' style={{ backgroundColor: colorOne, color: colorTwo }}>
+      <code className='f6 f4-ns mb2 db fw6'>{colorOne}</code>
+      <code className='f6 f5-ns mb2 db'>{Color(colorOne).hslString()}</code>
+      <code className='f6 f5-ns mb2 mb4-ns db'>{Color(colorOne).rgbString()}</code>
+      <h3 className='f3 f1-m f-headline-l mv0'>Aa Bb Cc</h3>
+      <p className='lh-copy measure'>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod.
+        <span className='dn di-ns'>Tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.</span>
+      </p>
+    </div>
+    <div className='fl w-100 w-50-ns pv4 ph4' style={{ backgroundColor: colorTwo, color: colorOne }}>
+      <code className='f6 f4-ns fw6 mb2 db'>{colorTwo}</code>
+      <code className='f6 f5-ns mb2 db'>{Color(colorTwo).hslString()}</code>
+      <code className='f6 f5-ns mb2 mb4-ns db'>{Color(colorTwo).rgbString()}</code>
+      <h3 className='f3 f1-m f-headline-l mv0'>Aa Bb Cc</h3>
+      <p className='lh-copy measure'>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod.
+        <span className='dn di-ns'>Tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.</span>
+      </p>
+    </div>
+  </section>
+)
 
 Combination.propTypes = {
   colorOne: PropTypes.string.isRequired,

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,30 +1,28 @@
 import React from 'react'
 
-const Footer = () => {
-  return (
-    <footer className='ph4 pt4 pb5 bt b--black-10 cf'>
-      <a href='https://twitter.com/share' className='dib ml3-ns fr-ns dim f6 ttu fw6 link mb4 twitter-share-button bg-blue white br1 ph3 pv2' data-via='mrmrs_' data-size='large'>Tweet This</a>
-      <h3 className='fw6 f5'>What is this?</h3>
-      <p className='mt0 measure f4 lh-copy'>
-         An ongoing project to try and curate beautiful color palettes that are a11y friendly.
-        This app generates a random palette and allows you to vote the combination up or down.
-        We'll store the info and <a href='/stats/' className='dim black'>keep our api open.</a>
-      </p>
-      <h4 className='f5 fw6'>What is a11y?</h4>
-      <p className='mt3 mb5 measure lh-copy'>
-         Accessibility (a11y) is a measure of a computer system's accessibility is to all people, including those with disabilities or impairments. It concerns both software and hardware and how they are configured in order to enable a disabled or impaired person to use that computer system successfully. Color contrast is just one part of accessibility you should consider.
-      </p>
-      <p className='mb3 f6 ttu tracked-normal gray'>
-        Built by <a href='http://twitter.com/4lpine' className='link gray dim fw6'>@4lpine</a> and <a href='http://twitter.com/mrmrs_' className='link gray dim fw6'>@mrmrs_</a>
-      </p>
-      <p className='mb3 f6 ttu tracked-normal gray'>
-        &lt;/&gt; <a href='https://github.com/johnotander/random-a11y' className='link gray dim fw6'>Front End</a> and <a href='https://github.com/johnotander/random-a11y-api' className='link gray dim fw6'>API</a>
-      </p>
-      <p className='mt5 gray'>
-        Related projects: <a href='//jxnblk.com/colorable' title='a11y contrast checker' className='link dim black fw6'>Colorable</a> <a href='//clrs.cc' title='A nicer color palette for the web.' className='dib ml2 link dim black fw6'>Colors</a> <a href='https://github.com/johnotander/random-a11y-combo' title='random a11y combo generator' className='dib ml2 link dim black fw6'>random-a11y-combo</a> <a href='https://github.com/johnotander/get-contrast' title='get contrast ratios and scores' className='dib ml2 link dim black fw6'>get-contrast</a>
-      </p>
-    </footer>
-  )
-}
+const Footer = () => (
+  <footer className='ph4 pt4 pb5 bt b--black-10 cf'>
+    <a href='https://twitter.com/share' className='dib ml3-ns fr-ns dim f6 ttu fw6 link mb4 twitter-share-button bg-blue white br1 ph3 pv2' data-via='mrmrs_' data-size='large'>Tweet This</a>
+    <h3 className='fw6 f5'>What is this?</h3>
+    <p className='mt0 measure f4 lh-copy'>
+        An ongoing project to try and curate beautiful color palettes that are a11y friendly.
+      This app generates a random palette and allows you to vote the combination up or down.
+      We'll store the info and <a href='/stats/' className='dim black'>keep our api open.</a>
+    </p>
+    <h4 className='f5 fw6'>What is a11y?</h4>
+    <p className='mt3 mb5 measure lh-copy'>
+        Accessibility (a11y) is a measure of a computer system's accessibility is to all people, including those with disabilities or impairments. It concerns both software and hardware and how they are configured in order to enable a disabled or impaired person to use that computer system successfully. Color contrast is just one part of accessibility you should consider.
+    </p>
+    <p className='mb3 f6 ttu tracked-normal gray'>
+      Built by <a href='http://twitter.com/4lpine' className='link gray dim fw6'>@4lpine</a> and <a href='http://twitter.com/mrmrs_' className='link gray dim fw6'>@mrmrs_</a>
+    </p>
+    <p className='mb3 f6 ttu tracked-normal gray'>
+      &lt;/&gt; <a href='https://github.com/johnotander/random-a11y' className='link gray dim fw6'>Front End</a> and <a href='https://github.com/johnotander/random-a11y-api' className='link gray dim fw6'>API</a>
+    </p>
+    <p className='mt5 gray'>
+      Related projects: <a href='//jxnblk.com/colorable' title='a11y contrast checker' className='link dim black fw6'>Colorable</a> <a href='//clrs.cc' title='A nicer color palette for the web.' className='dib ml2 link dim black fw6'>Colors</a> <a href='https://github.com/johnotander/random-a11y-combo' title='random a11y combo generator' className='dib ml2 link dim black fw6'>random-a11y-combo</a> <a href='https://github.com/johnotander/get-contrast' title='get contrast ratios and scores' className='dib ml2 link dim black fw6'>get-contrast</a>
+    </p>
+  </footer>
+)
 
 export default Footer

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,12 +1,10 @@
 import React from 'react'
 
-const Header = () => {
-  return (
-    <header className='bg-white ph4 pv3 bb b--black-10 dt w-100'>
-        <h1 className='f3 mv0 fw6 mr4 dib'>Random A11y Color Palettes</h1>
-        <h2 className='gray f5 fw4 mt2 mb0'>Vote on which a11y friendly color combinations look nice.</h2>
-    </header>
-  )
-}
+const Header = () => (
+  <header className='bg-white ph4 pv3 bb b--black-10 dt w-100'>
+    <h1 className='f3 mv0 fw6 mr4 dib'>Random A11y Color Palettes</h1>
+    <h2 className='gray f5 fw4 mt2 mb0'>Vote on which a11y friendly color combinations look nice.</h2>
+  </header>
+)
 
 export default Header

--- a/src/components/Notification.js
+++ b/src/components/Notification.js
@@ -1,12 +1,10 @@
 import React, { PropTypes } from 'react'
 
-const Notification = ({ children }) => {
-  return (
-    <div className='bg-black near-white tc pv2 fixed left-0 top-0 right-0'>
-      <p className='fw6 ttu tracked mv0'>{children}</p>
-    </div>
-  )
-}
+const Notification = ({ children }) => (
+  <div className='bg-black near-white tc pv2 fixed left-0 top-0 right-0'>
+    <p className='fw6 ttu tracked mv0'>{children}</p>
+  </div>
+)
 
 Notification.propTypes = {
   children: PropTypes.object


### PR DESCRIPTION
When you’re writing stateless React components, there are two methods:

```js
const Thing = () => {
  // you could write js here
  return (
    <div />
  )
}
```

or:

```js
const Thing = () => (
  // jumping write into the jsx
  <div />
)
```

If you’re not calculating anything before you render, the `{ return ( ) }` is unnecessary and you can just use the second method. This PR updates all four components to use the second method.