### PR TITLE
Remove floats from Combination

### DIFF
--- a/src/components/Combination.js
+++ b/src/components/Combination.js
@@ -2,8 +2,8 @@ import React, { PropTypes } from 'react'
 import Color from 'color'
 
 const Combination = ({ colorOne, colorTwo }) => (
-  <section className='cf bg-white'>
-    <div className='fl w-100 w-50-ns pv4 ph4' style={{ backgroundColor: colorOne, color: colorTwo }}>
+  <section className='bg-white'>
+    <div className='dib w-100 w-50-ns pv4 ph4' style={{ backgroundColor: colorOne, color: colorTwo }}>
       <code className='f6 f4-ns mb2 db fw6'>{colorOne}</code>
       <code className='f6 f5-ns mb2 db'>{Color(colorOne).hslString()}</code>
       <code className='f6 f5-ns mb2 mb4-ns db'>{Color(colorOne).rgbString()}</code>
@@ -13,7 +13,7 @@ const Combination = ({ colorOne, colorTwo }) => (
         <span className='dn di-ns'>Tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.</span>
       </p>
     </div>
-    <div className='fl w-100 w-50-ns pv4 ph4' style={{ backgroundColor: colorTwo, color: colorOne }}>
+    <div className='dib w-100 w-50-ns pv4 ph4' style={{ backgroundColor: colorTwo, color: colorOne }}>
       <code className='f6 f4-ns fw6 mb2 db'>{colorTwo}</code>
       <code className='f6 f5-ns mb2 db'>{Color(colorTwo).hslString()}</code>
       <code className='f6 f5-ns mb2 mb4-ns db'>{Color(colorTwo).rgbString()}</code>


### PR DESCRIPTION
I could be wrong, but I don’t see any issue with removing the floats (and clearfix) from the two panels of the Combination component. It works just fine with inline blocks, on all breakpoints 😀 

![screen shot 2016-07-20 at 8 48 52 pm](https://cloud.githubusercontent.com/assets/5074763/17008013/669ab2fa-4ebb-11e6-801e-7098a49ebbfe.png)