### PR TITLE
Add CSS code for combinations

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.9.0",
     "color": "^0.11.3",
+    "color-namer": "^1.1.0",
     "css-loader": "^0.23.1",
     "eslint": "^3.1.1",
     "eslint-loader": "^1.4.1",

--- a/src/components/Css.js
+++ b/src/components/Css.js
@@ -1,0 +1,34 @@
+
+import React, { PropTypes } from 'react'
+import namer from 'color-namer'
+
+const colorProcess = color => {
+  return namer(color).pantone[0].name.replace(/\s/g, '-').toLowerCase()
+}
+
+const Css = ({ colorOne, colorTwo }) => {
+  const code = `
+.${colorProcess(colorOne)} { color: ${colorOne}; }
+.${colorProcess(colorTwo)} { color: ${colorTwo}; }
+.bg-${colorProcess(colorOne)} { background-color: ${colorOne}; }
+.bg-${colorProcess(colorTwo)} { background-color: ${colorTwo}; }
+`.replace(/^\s/, '')
+
+  return (
+    <div className='w-100 mw6 center'>
+      <h3 className='f5 fw6 pb1 mb2 bb b--black-10'>CSS</h3>
+      <pre
+        className='code bg-near-white dark-gray br1 mv0 pa2 pre f6 lh-copy'
+        style={{ WebkitOverflowScrolling: 'touch' }}
+        children={code}
+      />
+    </div>
+  )
+}
+
+Css.propTypes = {
+  colorOne: PropTypes.string.isRequired,
+  colorTwo: PropTypes.string.isRequired
+}
+
+export default Css

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -6,6 +6,7 @@ import Header from '../components/Header'
 import Footer from '../components/Footer'
 import Notification from '../components/Notification'
 import Combination from '../components/Combination'
+import Css from '../components/Css'
 
 import isPresent from 'is-present'
 import isBlank from 'is-blank'
@@ -158,6 +159,7 @@ const App = React.createClass({
               </p>
             </div>
           </div>
+          <Css colorOne={colorOne} colorTwo={colorTwo} />
         </div>
         <Footer />
       </div>


### PR DESCRIPTION
Delivers #8 — it adds CSS below the combination for the colors. For the class names, I’m grabbing the name of the closest available Pantone color. The code has momentum scrolling on iOS.

<img width="1440" alt="screen shot 2016-07-21 at 3 17 02 pm" src="https://cloud.githubusercontent.com/assets/5074763/17035658/9a8818a0-4f56-11e6-8ffa-9b2414b5386a.png">
