### PR TITLE
Copy CSS to clipboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.9.0",
+    "clipboard": "^1.5.12",
     "color": "^0.11.3",
     "color-namer": "^1.1.0",
     "css-loader": "^0.23.1",

--- a/src/components/ClipboardButton.js
+++ b/src/components/ClipboardButton.js
@@ -1,0 +1,20 @@
+
+import React from 'react'
+import Clipboard from 'clipboard'
+
+const ClipboardButton = () => {
+  const cx = 'dib bg-white black-90 br2 mt2 pv2 ph3 link ba b--black-10 dark-gray lh-solid f6 fw6'
+
+  new Clipboard('#copy') // eslint-disable-line no-new
+
+  return (
+    <button
+      data-clipboard-target='#css'
+      id='copy'
+      className={cx}
+      children='Copy'
+    />
+  )
+}
+
+export default ClipboardButton

--- a/src/components/Css.js
+++ b/src/components/Css.js
@@ -2,6 +2,8 @@
 import React, { PropTypes } from 'react'
 import namer from 'color-namer'
 
+import ClipboardButton from './ClipboardButton'
+
 const colorProcess = color => {
   return namer(color).pantone[0].name.replace(/\s/g, '-').toLowerCase()
 }
@@ -18,10 +20,12 @@ const Css = ({ colorOne, colorTwo }) => {
     <div className='w-100 mw6 center'>
       <h3 className='f5 fw6 pb1 mb2 bb b--black-10'>CSS</h3>
       <pre
+        id='css'
         className='code bg-near-white dark-gray br1 mv0 pa2 pre f6 lh-copy'
         style={{ WebkitOverflowScrolling: 'touch' }}
         children={code}
       />
+      <ClipboardButton />
     </div>
   )
 }


### PR DESCRIPTION
Using [Clipboard.js](https://clipboardjs.com), this PR adds a button to let one quickly copy the CSS to their clipboard.

<img width="717" alt="screen shot 2016-07-21 at 10 48 28 pm" src="https://cloud.githubusercontent.com/assets/5074763/17045196/7f7cca9e-4f95-11e6-8d75-6852b23a5980.png">
