### PR TITLE
Fix currentVote bug

### DIFF
--- a/src/store/reducers/votes/index.js
+++ b/src/store/reducers/votes/index.js
@@ -29,8 +29,7 @@ const votesReducer = (state = initialState, action = {}) => {
 
     case SET_CURRENT_COMBO:
       return state.merge({
-        currentCombo: action.combo,
-        currentVote: null
+        currentCombo: action.combo
       })
 
     default:

--- a/src/store/reducers/votes/votes-test.js
+++ b/src/store/reducers/votes/votes-test.js
@@ -35,11 +35,6 @@ test('SEND_DOWNVOTE sets currentVote to "down"', t => {
   t.deepEqual(state.get('currentVote'), 'down')
 })
 
-test('SET_CURRENT_COMBO sets currentVote to null', t => {
-  state = fireAction(SET_CURRENT_COMBO, state, combo)
-  t.true(isBlank(state.get('currentVote')))
-})
-
 const fireAction = (type, currentState, combo) => (
   votesReducer(currentState, { type, combo })
 )


### PR DESCRIPTION
Discovered a bug earlier today that prevents the `currentVote` prop from correctly going to the main App render, because `SET_CURRENT_COMBO`, which was being run after the upvoting/downvoting actions, set `currentVote` to null. Quick fix 😀 